### PR TITLE
Remove vendor name from registerModule

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -6,7 +6,7 @@ if (!defined('TYPO3_MODE')) {
 call_user_func(
     function () {
          \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-            'In2code.in2help',
+            'In2help',
             'help',
             'm1',
             '',


### PR DESCRIPTION
because the argument $extensionName containing the vendor name is deprecated and do not work since TYPO3 11

See: https://docs.typo3.org/c/typo3/cms-core/11.5/en-us/Changelog/10.0/Deprecation-87550-UseControllerClassesWhenRegisteringPluginsmodules.html